### PR TITLE
[draw] fix centering on higher resolution screens

### DIFF
--- a/makai/wwwroot/draw/simpledraw2.js
+++ b/makai/wwwroot/draw/simpledraw2.js
@@ -683,8 +683,8 @@ SimpleDraw.prototype.RefreshLocation = function()
    //console.log(rect);
    console.trace("Refreshing location. x: " + this.x + ", y: " + this.y +
       ", easelw: " + rect.width + ", easelh: " + rect.h);
-   this.canvasContainer.style.top = (cont.height - rect.height) / 2 + this.y + "px";
-   this.canvasContainer.style.left = (cont.width - rect.width) / 2 + this.x + "px";
+   this.canvasContainer.style.top = "calc(50% - " + rect.width + "px)";
+   this.canvasContainer.style.left = "calc(50% - " + rect.height + "px)";
 };
 
 SimpleDraw.prototype.ResetNavigation = function()


### PR DESCRIPTION
when going on draw on my macbook, i noticed that the zoom was really off-center. this patch should fix it.

broken
<img width="1680" alt="Screen Shot 2021-11-17 at 8 10 02 AM" src="https://user-images.githubusercontent.com/18371895/142207081-4a2d0592-1c4a-4c5a-bb5b-3174595cbc36.png">

fixed
<img width="1680" alt="Screen Shot 2021-11-17 at 8 10 18 AM" src="https://user-images.githubusercontent.com/18371895/142207101-10a4d515-04b0-4a36-b8e1-1ca2d65bd233.png">
